### PR TITLE
Reset login error on logout

### DIFF
--- a/index.html
+++ b/index.html
@@ -856,6 +856,7 @@
         document.getElementById("loginPage").style.display = "flex";
         document.getElementById("userIdInput").value = "";
         document.getElementById("passwordInput").value = "";
+        document.getElementById("loginError").style.display = "none";
       },
       updateDashboardAndProgressBars: (timeframe) => Promise.all([updateDashboardMetrics(timeframe), updateAchievements()]),
       updateLeaderboards,


### PR DESCRIPTION
## Summary
- hide the login error banner when logging out so it doesn't persist

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684befb859648324aa1bc99a2f49b8f3